### PR TITLE
[CNSMR-2638] Fix the navigation bar scrolling performance issue.

### DIFF
--- a/Sources/UI/Flow.storyboard
+++ b/Sources/UI/Flow.storyboard
@@ -35,7 +35,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="v4V-Us-h8K" customClass="WHCollectionView" customModule="Wormholy" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.90588235294117647" green="0.90588235294117647" blue="0.90588235294117647" alpha="1" colorSpace="calibratedRGB"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="8" minimumInteritemSpacing="0.0" sectionInsetReference="safeArea" id="o7G-P5-gW8">
                                     <size key="itemSize" width="50" height="50"/>
@@ -52,10 +52,10 @@
                         </subviews>
                         <color key="backgroundColor" red="0.90588235294117647" green="0.90588235294117647" blue="0.90588235294117647" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="v4V-Us-h8K" firstAttribute="bottom" secondItem="9Dg-qw-sac" secondAttribute="bottom" id="Bfc-3a-gZU"/>
-                            <constraint firstItem="v4V-Us-h8K" firstAttribute="leading" secondItem="9Dg-qw-sac" secondAttribute="leading" id="BhY-Uv-5gP"/>
-                            <constraint firstItem="v4V-Us-h8K" firstAttribute="top" secondItem="9Dg-qw-sac" secondAttribute="top" id="Gmh-YD-YLf"/>
-                            <constraint firstItem="v4V-Us-h8K" firstAttribute="trailing" secondItem="9Dg-qw-sac" secondAttribute="trailing" id="vVH-ir-41b"/>
+                            <constraint firstItem="v4V-Us-h8K" firstAttribute="bottom" secondItem="NrO-gO-tFr" secondAttribute="bottom" id="Bfc-3a-gZU"/>
+                            <constraint firstItem="v4V-Us-h8K" firstAttribute="leading" secondItem="NrO-gO-tFr" secondAttribute="leading" id="BhY-Uv-5gP"/>
+                            <constraint firstItem="v4V-Us-h8K" firstAttribute="top" secondItem="NrO-gO-tFr" secondAttribute="top" id="Gmh-YD-YLf"/>
+                            <constraint firstItem="v4V-Us-h8K" firstAttribute="trailing" secondItem="NrO-gO-tFr" secondAttribute="trailing" id="vVH-ir-41b"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="9Dg-qw-sac"/>
                     </view>


### PR DESCRIPTION
https://babylonpartners.atlassian.net/browse/CNSMR-2638

The collection view is currently pinned to the safe area. As the safe area is changed as the navigation bar expands itself (for the large title & the search bar), this causes unnecessary layout invalidation.

Pin the collection view to the bound edges instead, so that its size is constant regardless of how the navigation bar changes.