### PR TITLE
[CNSMR-2637] Request rewrite mechanism for debugging & prototyping.

### DIFF
--- a/Sources/RewriteRule.swift
+++ b/Sources/RewriteRule.swift
@@ -1,0 +1,9 @@
+public struct RewriteRule {
+    public let urlPredicate: NSPredicate
+    public let transform: (URLRequest) -> URLRequest
+
+    public init(urlPredicate: NSPredicate, transform: @escaping (URLRequest) -> URLRequest) {
+        self.urlPredicate = urlPredicate
+        self.transform = transform
+    }
+}

--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -9,8 +9,23 @@
 import Foundation
 import UIKit
 
-public class Wormholy: NSObject
-{
+public class Wormholy: NSObject {
+    private static var _rewriteRules: [RewriteRule] = []
+    private static var _rewriteRulesLock = NSLock()
+
+    public static var rewriteRules: [RewriteRule] {
+        get {
+            _rewriteRulesLock.lock()
+            defer { _rewriteRulesLock.unlock() }
+            return _rewriteRules
+        }
+        set {
+            _rewriteRulesLock.lock()
+            defer { _rewriteRulesLock.unlock() }
+            _rewriteRules = newValue
+        }
+    }
+
     @objc public static func swiftyLoad() {
         NotificationCenter.default.addObserver(forName: fireWormholy, object: nil, queue: nil) { (notification) in
             Wormholy.presentWormholyFlow()

--- a/Wormholy.xcodeproj/project.pbxproj
+++ b/Wormholy.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		45FF5C5220877A950084BD50 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FF5C5120877A950084BD50 /* Section.swift */; };
 		45FF5C54208794720084BD50 /* WHDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FF5C53208794720084BD50 /* WHDate.swift */; };
 		52D6D9871BEFF229002C0205 /* Wormholy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* Wormholy.framework */; };
+		6567D322230C3C4100679B9E /* RewriteRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6567D321230C3C4100679B9E /* RewriteRule.swift */; };
 		8933C7851EB5B820000D00A4 /* Wormholy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* Wormholy.swift */; };
 		8933C7901EB5B82D000D00A4 /* WormholyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* WormholyTests.swift */; };
 		93A86AB12228349F006E56FB /* SwiftySelfAwareHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A86AB02228349F006E56FB /* SwiftySelfAwareHelper.swift */; };
@@ -124,6 +125,7 @@
 		45FF5C53208794720084BD50 /* WHDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHDate.swift; sourceTree = "<group>"; };
 		52D6D97C1BEFF229002C0205 /* Wormholy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Wormholy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9861BEFF229002C0205 /* Wormholy-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Wormholy-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6567D321230C3C4100679B9E /* RewriteRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewriteRule.swift; sourceTree = "<group>"; };
 		8933C7841EB5B820000D00A4 /* Wormholy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wormholy.swift; sourceTree = "<group>"; };
 		8933C7891EB5B82A000D00A4 /* WormholyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WormholyTests.swift; sourceTree = "<group>"; };
 		93A86AB02228349F006E56FB /* SwiftySelfAwareHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftySelfAwareHelper.swift; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 		8933C7811EB5B7E0000D00A4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				6567D321230C3C4100679B9E /* RewriteRule.swift */,
 				8933C7841EB5B820000D00A4 /* Wormholy.swift */,
 				455818C1207D61A100D2F954 /* CustomHTTPProtocol.swift */,
 				455818C2207D61A100D2F954 /* Storage.swift */,
@@ -546,6 +549,7 @@
 				453A167720ED1B02001CEB9D /* WHString.swift in Sources */,
 				452CC1322175FDB200CB5E21 /* CustomActivity.swift in Sources */,
 				45868F1420F4E2B10024C77B /* BodyDetailViewController.swift in Sources */,
+				6567D322230C3C4100679B9E /* RewriteRule.swift in Sources */,
 				45FF5C5220877A950084BD50 /* Section.swift in Sources */,
 				451C9E6920810B98002A34BC /* WHCollectionView.swift in Sources */,
 				45C4F4F320860FBC007D0D17 /* WHTextView.swift in Sources */,

--- a/WormholyDemo/ViewController.swift
+++ b/WormholyDemo/ViewController.swift
@@ -8,11 +8,28 @@
 
 import UIKit
 import Foundation
+import Wormholy
 
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Rewrite all requests with a path starting with `/posts/1`.
+        Wormholy.rewriteRules = [
+            RewriteRule(
+                urlPredicate: NSPredicate(format: "path BEGINSWITH %@", "/posts/1"),
+                transform: { request in
+                    var request = request
+                    var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
+                    components.host = "localhost"
+                    components.path = "/rewrited" + components.path
+                    request.url = components.url!
+                    return request
+                }
+            )
+        ]
+
         if #available(iOS 10.0, *) {
             let timer = Timer.scheduledTimer(withTimeInterval: 8, repeats: true) { (timer) in
                 DataFetcher.sharedInstance.getPost(id: Utils.random(max: 128), completion: {


### PR DESCRIPTION
Ref: https://babylonpartners.atlassian.net/browse/CNSMR-2637

Provide a mechanism for users to rewrite matching URL requests for debugging and prototyping purposes.

As an example, we added this rewrite rule at app launch time to route chat APIs to a local stack.

```swift
        Wormholy.rewriteRules = [
            RewriteRule(
                urlPredicate: NSPredicate(
                    format: "host BEGINSWITH %@ AND path BEGINSWITH %@",
                    "services-uk.",
                    "/chatscript/v3/"
                ),
                transform: { request in
                    var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
                    components.scheme = "http"
                    components.host = "192.168.xxx.xxx"
                    components.port = 8080
                    components.path = components.path.replacingOccurrences(of: "chatscript", with: "chatbot")

                    var request = request
                    request.url = components.url!
                    request.addValue("chatbot-prototype", forHTTPHeaderField: "X-Principal")

                    if request.httpMethod == "POST", components.path.hasSuffix("v3/conversations") {
                        request.allHTTPHeaderFields!["X-App-Name"] = "babylon"
                    }

                    return request
                }
            )
        ]
```