### PR TITLE
Blacklist MVP. Put a cap on lines used on path & query in RequestCell.

### DIFF
--- a/Sources/CustomHTTPProtocol.swift
+++ b/Sources/CustomHTTPProtocol.swift
@@ -17,6 +17,7 @@ public class CustomHTTPProtocol: URLProtocol {
     var session: URLSession?
     var sessionTask: URLSessionDataTask?
     var currentRequest: RequestModel?
+    var isBlacklistedForStorage = false
     
     override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
         super.init(request: request, cachedResponse: cachedResponse, client: client)
@@ -49,8 +50,9 @@ public class CustomHTTPProtocol: URLProtocol {
         sessionTask?.resume()
         
         currentRequest = RequestModel(request: requestObject)
+        isBlacklistedForStorage = Wormholy.blacklist.contains { $0.urlPredicate.evaluate(with: modifiedRequest.url) }
 
-        if let request = currentRequest {
+        if !isBlacklistedForStorage, let request = currentRequest {
             Storage.shared.saveRequest(request: request)
         }
     }
@@ -62,7 +64,7 @@ public class CustomHTTPProtocol: URLProtocol {
             currentRequest?.duration = fabs(startDate.timeIntervalSinceNow) * 1000 //Find elapsed time and convert to milliseconds
         }
 
-        if let request = currentRequest {
+        if !isBlacklistedForStorage, let request = currentRequest {
             Storage.shared.saveRequest(request: request)
         }
 

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -1,0 +1,9 @@
+public struct Filter {
+    public let name: String
+    public let urlPredicate: NSPredicate
+
+    public init(name: String, urlPredicate: NSPredicate) {
+        self.name = name
+        self.urlPredicate = urlPredicate
+    }
+}

--- a/Sources/UI/Cells/RequestCell.xib
+++ b/Sources/UI/Cells/RequestCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,7 +18,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView verifyAmbiguity="off" opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" distribution="equalSpacing" alignment="center" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="m5V-nA-Yy8" userLabel="Left Stack">
-                        <rect key="frame" x="0.0" y="0.0" width="54.5" height="90"/>
+                        <rect key="frame" x="0.0" y="0.0" width="33" height="90"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="CODE" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="day-sD-Vbl" customClass="WHLabel" customModule="Wormholy" customModuleProvider="target">
                                 <rect key="frame" x="0.5" y="0.0" width="32" height="18"/>
@@ -51,7 +49,7 @@
                         </subviews>
                     </stackView>
                     <stackView verifyAmbiguity="off" opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Be5-zC-dPn" userLabel="Right Stack">
-                        <rect key="frame" x="60" y="12" width="311.5" height="90"/>
+                        <rect key="frame" x="60" y="12" width="333" height="90"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="999" text="thisisaveryveryveryveryveryveryveryveryverylongurl.com" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VbY-eq-0R8" customClass="WHLabel" customModule="Wormholy" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="298" height="13.5"/>
@@ -59,13 +57,13 @@
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="999" verticalCompressionResistancePriority="999" text="/really/very/long/path/" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EUu-iz-8qR" customClass="WHLabel" customModule="Wormholy" customModuleProvider="target">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="999" verticalCompressionResistancePriority="999" text="/really/very/long/path/" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EUu-iz-8qR" customClass="WHLabel" customModule="Wormholy" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="17.5" width="149" height="18"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="998" verticalCompressionResistancePriority="999" text="?param=value" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ojh-s5-hEx" customClass="WHLabel" customModule="Wormholy" customModuleProvider="target">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="998" verticalCompressionResistancePriority="999" text="?param=value" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ojh-s5-hEx" customClass="WHLabel" customModule="Wormholy" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="39.5" width="96" height="50.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.27209792792725673" green="0.67526728899122812" blue="0.70359264964788737" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -11,18 +11,32 @@ import UIKit
 
 public class Wormholy: NSObject {
     private static var _rewriteRules: [RewriteRule] = []
-    private static var _rewriteRulesLock = NSLock()
+    private static var _blacklist: [Filter] = []
+    private static var _configLock = NSLock()
 
     public static var rewriteRules: [RewriteRule] {
         get {
-            _rewriteRulesLock.lock()
-            defer { _rewriteRulesLock.unlock() }
+            _configLock.lock()
+            defer { _configLock.unlock() }
             return _rewriteRules
         }
         set {
-            _rewriteRulesLock.lock()
-            defer { _rewriteRulesLock.unlock() }
+            _configLock.lock()
+            defer { _configLock.unlock() }
             _rewriteRules = newValue
+        }
+    }
+
+    public static var blacklist: [Filter] {
+        get {
+            _configLock.lock()
+            defer { _configLock.unlock() }
+            return _blacklist
+        }
+        set {
+            _configLock.lock()
+            defer { _configLock.unlock() }
+            _blacklist = newValue
         }
     }
 

--- a/Wormholy.xcodeproj/project.pbxproj
+++ b/Wormholy.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		45FF5C54208794720084BD50 /* WHDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FF5C53208794720084BD50 /* WHDate.swift */; };
 		52D6D9871BEFF229002C0205 /* Wormholy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* Wormholy.framework */; };
 		6567D322230C3C4100679B9E /* RewriteRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6567D321230C3C4100679B9E /* RewriteRule.swift */; };
+		656D75C8235F6EC1002FE713 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656D75C7235F6EC1002FE713 /* Filter.swift */; };
 		8933C7851EB5B820000D00A4 /* Wormholy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7841EB5B820000D00A4 /* Wormholy.swift */; };
 		8933C7901EB5B82D000D00A4 /* WormholyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* WormholyTests.swift */; };
 		93A86AB12228349F006E56FB /* SwiftySelfAwareHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A86AB02228349F006E56FB /* SwiftySelfAwareHelper.swift */; };
@@ -126,6 +127,7 @@
 		52D6D97C1BEFF229002C0205 /* Wormholy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Wormholy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52D6D9861BEFF229002C0205 /* Wormholy-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Wormholy-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6567D321230C3C4100679B9E /* RewriteRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewriteRule.swift; sourceTree = "<group>"; };
+		656D75C7235F6EC1002FE713 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		8933C7841EB5B820000D00A4 /* Wormholy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wormholy.swift; sourceTree = "<group>"; };
 		8933C7891EB5B82A000D00A4 /* WormholyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WormholyTests.swift; sourceTree = "<group>"; };
 		93A86AB02228349F006E56FB /* SwiftySelfAwareHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftySelfAwareHelper.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 		8933C7811EB5B7E0000D00A4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				656D75C7235F6EC1002FE713 /* Filter.swift */,
 				6567D321230C3C4100679B9E /* RewriteRule.swift */,
 				8933C7841EB5B820000D00A4 /* Wormholy.swift */,
 				455818C1207D61A100D2F954 /* CustomHTTPProtocol.swift */,
@@ -541,6 +544,7 @@
 				45FF5C4A20875EFA0084BD50 /* WHView.swift in Sources */,
 				45868F1B20F4E9790024C77B /* ActionableTableViewCell.swift in Sources */,
 				455818C9207D621200D2F954 /* RequestModel.swift in Sources */,
+				656D75C8235F6EC1002FE713 /* Filter.swift in Sources */,
 				45C4F4EB20860D14007D0D17 /* WHTableView.swift in Sources */,
 				451C9E602080F653002A34BC /* WHBundle.swift in Sources */,
 				452CC13421773BF600CB5E21 /* FileHandler.swift in Sources */,


### PR DESCRIPTION
1. RequestCell now has a cap of 3 lines on the path, and a cap of 2 lines on the query.
2. Introduce _blacklist_ which excludes matching requests from the Request Stream.