### PR TITLE
Fix performance issue with Wormholy setup on app launch

### DIFF
--- a/Sources/Utils/SwiftySelfAwareHelper.swift
+++ b/Sources/Utils/SwiftySelfAwareHelper.swift
@@ -9,32 +9,10 @@
 import Foundation
 import UIKit
 
-protocol SelfAware: class {
-    static func awake()
-}
-
-struct CustomSelfAwareHelper {
-    
-    static func harmlessFunction() {
-        
-        // Get all class list through runtime
-        let typeCount = Int(objc_getClassList(nil, 0))
-        let types = UnsafeMutablePointer<AnyClass>.allocate(capacity: typeCount)
-        let autoreleasingTypes = AutoreleasingUnsafeMutablePointer<AnyClass>(types)
-        objc_getClassList(autoreleasingTypes, Int32(typeCount))
-        
-        for index in 0 ..< typeCount {
-            (types[index] as? SelfAware.Type)?.awake()
-        }
-        
-        types.deallocate()
-    }
-}
-
 extension UIApplication {
     
     private static let runOnce: Void = {
-        CustomSelfAwareHelper.harmlessFunction()
+        Wormholy.awake()
     }()
     
     override open var next: UIResponder? {

--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -129,7 +129,7 @@ public class Wormholy: NSObject {
     }()
 }
 
-extension Wormholy: SelfAware {
+extension Wormholy {
     
     static func awake() {
         initializeAction


### PR DESCRIPTION
On app launch Wormholy initialises itself by going through a list of all classes to ultimately call `Wormholy.awake()`.

It uses `SelfAware` protocol for this purpose, but the protocol is internal, so consumers of the framework can't define their own conformance and operation described above is very heavy. For performance gains we can remove `SelfAware` protocol and simply call `Womrholy.awake()`.

In my local tests there’s about 1.5 second difference thanks to the change.